### PR TITLE
Run Integration tests against SMAS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ executors:
     - image: circleci/php:<< parameters.php-version >>-browsers
       environment:
         CIRCLE_EXECUTOR: stack
-    - image: docker.elastic.co/elasticsearch/elasticsearch:7.2.0
+    - image: docker.elastic.co/elasticsearch/elasticsearch:7.3.0
       name: elasticsearch
       environment:
         cluster.name: es-cluster
@@ -23,7 +23,7 @@ executors:
         bootstrap.memory_lock: true
         discovery.type: single-node
         ES_JAVA_OPTS: "-Xms512m -Xmx512m"
-    - image: docker.elastic.co/app-search/app-search:7.2.0
+    - image: docker.elastic.co/app-search/app-search:7.3.0
       name: appsearch
       environment:
         elasticsearch.host: http://elasticsearch:9200


### PR DESCRIPTION
- [X] Execute PR integration testing on SMAS instead of SaaS.
- [X] Execute branch integration on SMAS and SaaS

An AppSearch instance (and the required ElasticSearch) is spotted as a docker container when using the stack executor. The script .circleci/retrieve-credentials.sh retrieve API keys from this instance. It will need to be rewritten in the future but I would be for merging in the current state.