### PR TITLE
Feature for local integration testing using docker compose

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ executors:
         elasticsearch.host: http://elasticsearch:9200
         allow_es_settings_modification: true
         app_search.listen_host: 0.0.0.0
-        JAVA_OPTS: "-Xms512m -Xmx512m"
+        JAVA_OPTS: "-Xms1024m -Xmx1024m"
 
 commands:
   install_deps:

--- a/.circleci/retrieve-credentials.sh
+++ b/.circleci/retrieve-credentials.sh
@@ -1,6 +1,7 @@
+export AS_URL=${AS_URL:-"http://localhost:3002"}
+
 #!/bin/bash
 function wait_for_as {
-  local AS_URL=${AS_URL:-"http://localhost:3002"}
   curl --connect-timeout 5 --max-time 10 --retry 10 --retry-delay 0 --retry-max-time 120 --retry-connrefuse -s -o /dev/null ${AS_URL}/login
 }
 
@@ -12,6 +13,6 @@ function load_api_keys {
 }
 
 wait_for_as
-AS_PRIVATE_KEY=`load_api_keys private`
-AS_SEARCH_KEY=`load_api_keys search`
+export AS_PRIVATE_KEY=`load_api_keys private`
+export AS_SEARCH_KEY=`load_api_keys search`
 unset -f load_api_keys

--- a/README.md
+++ b/README.md
@@ -201,6 +201,19 @@ You can then commit and PR the modified api-spec file and your endpoints code fi
 
 The client class and readme may be changed in some cases. Do not forget to include them in your commit!
 
+### Running CI tests locally
+
+Run phpunit tests with: 
+```bash
+vendor/bin/phpunit -c phpunit.xml.dist --testsuite unit
+```
+
+In order to run integration tests locally a [docker-compose](https://docs.docker.com/compose/install) configuration is included:
+```bash
+docker-compose up --detach
+vendor/bin/phpunit -c phpunit.xml.dist --testsuite integration
+```
+
 ## FAQ 🔮
 
 ### Where do I report issues with the client?

--- a/README.md
+++ b/README.md
@@ -211,6 +211,12 @@ vendor/bin/phpunit -c phpunit.xml.dist --testsuite unit
 In order to run integration tests locally a [docker-compose](https://docs.docker.com/compose/install) configuration is included:
 ```bash
 docker-compose up --detach
+```
+It takes a while for the containers to start. Once initialized run the integration tests:  
+```bash 
+export ES_URL="http://localhost:9200"
+export AS_URL="http://localhost:3002"
+source .circleci/retrieve-credentials.sh
 vendor/bin/phpunit -c phpunit.xml.dist --testsuite integration
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '3'
+services:
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.4.0
+#    name: elasticsearch
+    environment:
+      cluster.name: es-cluster
+      node.name: es-node
+      bootstrap.memory_lock: 'true'
+      discovery.type: single-node
+      ES_JAVA_OPTS: "-Xms512m -Xmx512m"
+    ports:
+      - "9200:9200"
+
+  appsearch:
+    image: docker.elastic.co/app-search/app-search:7.4.0
+#    name: appsearch
+    environment:
+      elasticsearch.host: http://elasticsearch:9200
+      allow_es_settings_modification: 'true'
+      app_search.listen_host: 0.0.0.0
+      JAVA_OPTS: "-Xms512m -Xmx512m"
+    ports:
+      - "3002:3002"


### PR DESCRIPTION
Add support for running CI tests locally. Provides a docker-compose file and instructions.
Also I had to increase memory size for the appsearch container in circleci as the higher PHP versions would randomly fail with out-of-memory errors