### PR TITLE
Added put synonyms

### DIFF
--- a/resources/api/api-spec.yml
+++ b/resources/api/api-spec.yml
@@ -552,6 +552,23 @@ paths:
       responses:
         default:
           $ref: "#/components/responses/jsonResponse"
+    put:
+      operationId: updateSynonymSet
+      summary: Update an existing synonym set by id.
+      externalDocs:
+        url: https://swiftype.com/documentation/app-search/api/synonyms#update
+      tags:
+      - Synonyms API
+      parameters:
+      - name: synonyms
+        in: query
+        required: true
+        description: List of synonyms words.
+        schema:
+          $ref: "#/components/schemas/synonymList"
+      responses:
+        default:
+          $ref: "#/components/responses/jsonResponse"
     delete:
       operationId: deleteSynonymSet
       summary: Delete a synonym set by id.

--- a/resources/api/api-spec.yml
+++ b/resources/api/api-spec.yml
@@ -123,6 +123,18 @@ components:
 
   # Reusable request bodies ----------------------------------------------------
   requestBodies:
+    synonymsIdsRequest:
+      required: true
+      description: List of synonym ids.
+      content:
+        application/json:
+          schema:
+            type: object
+            additionalProperties: false
+            properties:
+              synonyms:
+                $ref: "#/components/schemas/synonymList"
+
     documentIdsRequest:
       required: true
       description: List of document ids.
@@ -527,13 +539,8 @@ paths:
         url: https://swiftype.com/documentation/app-search/api/synonyms#create
       tags:
       - Synonyms API
-      parameters:
-      - name: synonyms
-        in: query
-        required: true
-        description: List of synonyms words.
-        schema:
-          $ref: "#/components/schemas/synonymList"
+      requestBody:
+        $ref: "#/components/requestBodies/synonymsIdsRequest"
       responses:
         default:
           $ref: "#/components/responses/jsonResponse"
@@ -559,13 +566,8 @@ paths:
         url: https://swiftype.com/documentation/app-search/api/synonyms#update
       tags:
       - Synonyms API
-      parameters:
-      - name: synonyms
-        in: query
-        required: true
-        description: List of synonyms words.
-        schema:
-          $ref: "#/components/schemas/synonymList"
+      requestBody:
+        $ref: "#/components/requestBodies/synonymsIdsRequest"
       responses:
         default:
           $ref: "#/components/responses/jsonResponse"


### PR DESCRIPTION
**Changes**

1. Added a missing PUT endpoint for synonyms - This was missing from the docs and this spec, but it does exist.
1. Changed synonyms POST and PUT to use requestBody - It was using query string parameters before, which I'm not sure was quite right.

I will be adding the corresponding section to the documentation: https://swiftype.com/documentation/app-search/api/synonyms#update