### PR TITLE
fix a typo invalid reference in api spec

### DIFF
--- a/resources/api/api-spec.yml
+++ b/resources/api/api-spec.yml
@@ -425,7 +425,7 @@ paths:
         required: true
         description: Search queries.
         schema:
-          $ref: "#/components/schema/searchRequestList"
+          $ref: "#/components/schemas/searchRequestList"
       responses:
         default:
           $ref: "#/components/responses/jsonResponse"


### PR DESCRIPTION
Rebased on 7.2 and pushed again