### PR TITLE
Test image artifact

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,8 +100,7 @@ jobs:
     - image: circleci/golang:1.13-alpine
     steps:
     - checkout
-    - setup_remote_docker:
-        docker_layer_caching: true
+    - setup_remote_docker
     - run: 
         name: Building docker test image
         command: docker build . --target test_image -t elastic/app_search_php_client_test:latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,4 +159,7 @@ workflows:
         executor: { name: stack, php-version: "5.6" }
   build-test-artifacts:
     jobs:
-    - build-test-image
+    - build-test-image:
+        filters:
+          branches:
+            only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,7 @@ jobs:
         command: vendor/bin/phpcs --ignore=vendor,resources .
   build-test-image:
     docker:
-    - image: circleci/golang:1.13-alpine
+    - image: circleci/golang
     steps:
     - checkout
     - setup_remote_docker
@@ -157,6 +157,6 @@ workflows:
     - integration-tests:
         name: php-56-integration-tests
         executor: { name: stack, php-version: "5.6" }
-  test-artifacts:
+  build-test-artifacts:
     jobs:
     - build-test-image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,6 +95,22 @@ jobs:
     - run:
         name: PHPCS
         command: vendor/bin/phpcs --ignore=vendor,resources .
+  build-test-image:
+    docker:
+    - image: circleci/golang:1.13-alpine
+    steps:
+    - checkout
+    - setup_remote_docker:
+        docker_layer_caching: true
+    - run: 
+        name: Building docker test image
+        command: docker build . --target test_image -t elastic/app_search_php_client_test:latest
+    - run: 
+        name: Export docker test image
+        command: docker save elastic/app_search_php_client_test:latest | gzip -9 > app_search_php_client_test_docker_image.tar.gz
+    - store_artifacts:
+        path: ./app_search_php_client_test_docker_image.tar.gz
+        destination: app_search_php_client_test_docker_image.tar.gz
 
 workflows:
   version: 2
@@ -142,3 +158,6 @@ workflows:
     - integration-tests:
         name: php-56-integration-tests
         executor: { name: stack, php-version: "5.6" }
+  test-artifacts:
+    jobs:
+    - build-test-image

--- a/.circleci/retrieve-credentials.sh
+++ b/.circleci/retrieve-credentials.sh
@@ -10,7 +10,6 @@ function wait_for_as {
       sleep 1
     fi
   done
-  set -e
 }
 
 function load_api_keys {

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG base_image=php:7.2-cli
-FROM $base_image
+FROM $base_image as builder
 
 # Installing additional tools
 RUN apt-get update \
@@ -11,3 +11,10 @@ RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
  && php composer-setup.php \
  && php -r "unlink('composer-setup.php');" \
  && mv composer.phar /usr/local/bin/composer
+
+
+FROM builder as test_image
+
+WORKDIR /app
+COPY . /app/
+RUN composer install

--- a/scripts/tests/run-tests.sh
+++ b/scripts/tests/run-tests.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+
+source .circleci/retrieve-credentials.sh
+
+echo "Running unit tests"
+vendor/bin/phpunit -c phpunit.xml.dist --testsuite unit
+
+echo "Running integration tests"
+vendor/bin/phpunit -c phpunit.xml.dist --testsuite integration


### PR DESCRIPTION
- [X] Prepare the docker test image 
- [x] Build the test image as part of the CI process and add it to the artifacts
- [x] Limit the step to the master branch

The master branch build produces a docker image as an artifact that you can use for testing the client against a specific build of Enterprise Search.

