### PR TITLE
Fix CI tests for 7.8.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,7 @@ executors:
         discovery.type: single-node
         xpack.security.enabled: true
         xpack.license.self_generated.type: trial
+        xpack.security.authc.api_key.enabled: true
         ELASTIC_PASSWORD: password
     - image: docker.elastic.co/enterprise-search/enterprise-search:7.8.0
       name: appsearch


### PR DESCRIPTION
Fixes a regression in CI integration tests caused by upgrading Enterprise Search and Elasticsearch to 7.8.0 in https://github.com/elastic/app-search-php/commit/bc33eebcb9f909d857a7ac1c085a70609544252f

The CI tests fail with:
```
--------------------------------------------------------------------------------
Elasticsearch API key service must be enabled. It is enabled automatically when you configure Elasticsearch to use TLS on the HTTP interface.
Alternatively, you can explicitly enable the setting within Elasticsearch by opening config/elasticsearch.yml and adding:

xpack.security.authc.api_key.enabled: true
--------------------------------------------------------------------------------
```

This PR adds that setting to Elasticsearch.