### PR TITLE
Fix #41: Flaky doc test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,7 @@ executors:
         discovery.type: single-node
         xpack.security.enabled: true
         xpack.license.self_generated.type: trial
+        xpack.security.authc.api_key.enabled: true
         ELASTIC_PASSWORD: password
     - image: docker.elastic.co/enterprise-search/enterprise-search:7.8.0
       name: appsearch

--- a/Tests/Integration/DocumentApiTest.php
+++ b/Tests/Integration/DocumentApiTest.php
@@ -78,6 +78,7 @@ class DocumentApiTest extends AbstractEngineTestCase
         $client = $this->getDefaultClient();
         $documentIds = array_column($documents, 'id');
         $client->indexDocuments($engineName, $documents);
+        $this->waitForIndexing();
 
         $client->deleteDocuments($engineName, [current($documentIds)]);
         $this->waitForIndexing();
@@ -124,6 +125,6 @@ class DocumentApiTest extends AbstractEngineTestCase
 
     private function waitForIndexing()
     {
-        sleep(1);
+        sleep(10);
     }
 }


### PR DESCRIPTION
Fixes issue #41 

I opted to increase the sleep time to 10s instead of implementing a more complex fix, such as polling for an expected condition. If documents are not indexed within 10s, and also not deleted within 10s, something is likely wrong. There aren't a lot of tests that depend on this sleep condition, so it should not add more than 1 minute to the test run times.