### PR TITLE
Deprecate client in favor of enterprise-search-php

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
+> **⚠️ This client is deprecated ⚠️**
+>
+> As of Enterprise Search version 7.13.0, we are directing users to the new [Enterprise Search PHP Client](https://github.com/elastic/enterprise-search-php) and
+> deprecating this client.
+>
+> This client will be compatible with all Enterprise Search 7.x releases, but will not be compatible with 8.x releases. Our development effort on this project will
+> be limited to bug fixes. All future enhancements will be focused on the Enterprise Search PHP Client.
+>
+> Thank you! - Elastic
+
+
 <p align="center"><img src="https://github.com/elastic/app-search-php/blob/master/logo-app-search.png?raw=true" alt="Elastic App Search Logo"></p>
 
 <p align="center"><a href="https://circleci.com/gh/elastic/app-search-php"><img src="https://circleci.com/gh/elastic/app-search-php.svg" alt="CircleCI buidl"></a></p>


### PR DESCRIPTION
Issue deprecation notices for this version of the client. Future development is happening in the [Enterprise Search PHP Client](https://github.com/elastic/enterprise-search-php)